### PR TITLE
refactor: safe token transfers and payout interval fix

### DIFF
--- a/libraries/AjoV1Library.sol
+++ b/libraries/AjoV1Library.sol
@@ -8,6 +8,19 @@ import {AjoV1Factory} from "../contracts/AjoV1Factory.sol";
 library AjoV1Library {
     event FeePaid(address indexed feeTo, uint256 amount);
 
+    /// @dev Handles tokens like USDT that do not return a bool from transfer/transferFrom.
+    function safeTransfer(address token, address to, uint256 value) internal {
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, value));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "AjoV1Library: Transfer failed");
+    }
+
+    /// @dev Handles tokens like USDT that do not return a bool from transfer/transferFrom.
+    function safeTransferFrom(address token, address from, address to, uint256 value) internal {
+        (bool success, bytes memory data) =
+            token.call(abi.encodeWithSelector(IERC20.transferFrom.selector, from, to, value));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "AjoV1Library: TransferFrom failed");
+    }
+
     function transferFee(uint256 _totalAmount, address _contributionToken, address _factory)
         internal
         returns (uint256)
@@ -16,11 +29,11 @@ library AjoV1Library {
         address feeTo = AjoV1Factory(_factory).feeTo();
         uint256 feeAmount = (_totalAmount * feePercentage) / 100;
         if (feeAmount > 0) {
-            assert(IERC20(_contributionToken).transfer(feeTo, feeAmount));
+            safeTransfer(_contributionToken, feeTo, feeAmount);
             emit FeePaid(feeTo, feeAmount);
         }
         return feeAmount;
-    } 
+    }
 
     function removeAllOccurrences(address _address, address[] storage _list) internal {
         uint256 count = 0;


### PR DESCRIPTION
## Summary
- Add `safeTransfer` and `safeTransferFrom` helpers to `AjoV1Library` using low-level calls to support non-compliant tokens (e.g. USDT) that don't return a bool
- Replace all `assert(IERC20.transfer/transferFrom)` calls across `AjoV1LotteryPool`, `AjoV1SavingsPool`, and `AjoV1Library` with the new safe helpers
- Fix interval index search in `AjoV1SavingsPool.payout()` to correctly find the last interval ending at or before the given timestamp
- Store `intervals[targetIntervalIndex].endTimestamp` (not `block.timestamp`) as `lastPayoutTimestamp` for accurate off-chain tracking
- Minor: fix pragma spacing and SPDX comment indentation

## Test plan
- [ ] Deploy updated contracts to testnet and verify token transfers succeed for both compliant and non-compliant ERC20 tokens
- [ ] Test `payout()` with timestamps at interval boundaries to confirm correct interval is selected
- [ ] Verify `lastPayoutTimestamp` reflects interval end time, not block time

🤖 Generated with [Claude Code](https://claude.com/claude-code)